### PR TITLE
Fix serialization variables

### DIFF
--- a/core/src/main/scala/io/chrisdavenport/sbt/npmdependencies/NpmDependencies.scala
+++ b/core/src/main/scala/io/chrisdavenport/sbt/npmdependencies/NpmDependencies.scala
@@ -54,9 +54,9 @@ object NpmDependencies {
   implicit val encoder = Encoder.instance[NpmDependencies](npm => 
     Json.obj(
       "compile-dependencies" -> npm.compileDependencies.map(TupledMap.fromTuple).asJson,
-      "test-dependencies" -> npm.compileDependencies.map(TupledMap.fromTuple).asJson,
-      "compile-devDependencies" -> npm.compileDependencies.map(TupledMap.fromTuple).asJson,
-      "test-devDependencies" -> npm.compileDependencies.map(TupledMap.fromTuple).asJson,
+      "test-dependencies" -> npm.testDependencies.map(TupledMap.fromTuple).asJson,
+      "compile-devDependencies" -> npm.compileDevDependencies.map(TupledMap.fromTuple).asJson,
+      "test-devDependencies" -> npm.testDevDependencies.map(TupledMap.fromTuple).asJson,
     )  
   )
 


### PR DESCRIPTION
It was using just the `compileDependencies` multiple times in place of the others.

See https://github.com/davenverse/sbt-npm-dependencies/pull/1#discussion_r948320070